### PR TITLE
Fix regression failure with PG12

### DIFF
--- a/expected/pg_rational_test.out
+++ b/expected/pg_rational_test.out
@@ -75,12 +75,14 @@ select '1/2'::rational::float;
     0.5
 (1 row)
 
+set extra_float_digits = 0; -- default changed in PG12
 select '1/3'::rational::float;
       float8       
 -------------------
  0.333333333333333
 (1 row)
 
+reset extra_float_digits;
 select '-1/2'::rational::float;
  float8 
 --------

--- a/sql/pg_rational_test.sql
+++ b/sql/pg_rational_test.sql
@@ -26,7 +26,9 @@ select -0.5::float::rational;
 
 -- to float
 select '1/2'::rational::float;
+set extra_float_digits = 0; -- default changed in PG12
 select '1/3'::rational::float;
+reset extra_float_digits;
 select '-1/2'::rational::float;
 
 -- too big


### PR DESCRIPTION
PG12 changed the default for extra_float_digits to be 1, reset it to 0
here here here here to have the same output on all versions.

Close #10.