### PR TITLE
Add missing overflow checks to rational_in_float()

### DIFF
--- a/expected/pg_rational_test.out
+++ b/expected/pg_rational_test.out
@@ -68,6 +68,44 @@ select -0.5::float::rational;
  -1/2
 (1 row)
 
+select 1.000001::float::rational;
+    rational     
+-----------------
+ 1000001/1000000
+(1 row)
+
+select 1.0000001::float::rational;
+     rational     
+------------------
+ 10000000/9999999
+(1 row)
+
+select 1.00000001::float::rational;
+      rational       
+---------------------
+ 100000001/100000000
+(1 row)
+
+select 1.000000001::float::rational;
+      rational       
+---------------------
+ 999999918/999999917
+(1 row)
+
+select 1.0000000001::float::rational;
+ rational 
+----------
+ 1/1
+(1 row)
+
+select 2147483647::float::rational;
+   rational   
+--------------
+ 2147483647/1
+(1 row)
+
+select 2147483647.1::float::rational;
+ERROR:  value too large for rational
 -- to float
 select '1/2'::rational::float;
  float8 

--- a/expected/pg_rational_test.out
+++ b/expected/pg_rational_test.out
@@ -106,6 +106,8 @@ select 2147483647::float::rational;
 
 select 2147483647.1::float::rational;
 ERROR:  value too large for rational
+select 'NAN'::float::rational;
+ERROR:  value too large for rational
 -- to float
 select '1/2'::rational::float;
  float8 

--- a/pg_rational.c
+++ b/pg_rational.c
@@ -114,8 +114,7 @@ rational_in_float(PG_FUNCTION_ARGS)
 				fnumer,
 				fdenom,
 				error;
-	int32		temp,
-				prev_denom,
+	int32		prev_denom,
 				sign;
 	Rational   *result = palloc(sizeof(Rational));
 
@@ -129,7 +128,7 @@ rational_in_float(PG_FUNCTION_ARGS)
 	sign = target < 0.0 ? -1 : 1;
 	target = fabs(target);
 
-	if (target > INT32_MAX) {
+	if (!(target <= INT32_MAX)) { // also excludes NaN's
 		ereport(ERROR,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 				 errmsg("value too large for rational")));
@@ -142,13 +141,9 @@ rational_in_float(PG_FUNCTION_ARGS)
 	{
 		z = 1.0 / (z - floor(z));
 		fdenom = result->denom * floor(z) + prev_denom;
-		if (fdenom > INT32_MAX) {
-			break;
-		}
 		fnumer = round(target * fdenom);
-		if (fnumer > INT32_MAX) {
+		if (fnumer > INT32_MAX || fdenom > INT32_MAX )
 			break;
-		}
 		prev_denom = result->denom;
 		result->numer = (int32)fnumer;
 		result->denom = (int32)fdenom;

--- a/pg_rational.c
+++ b/pg_rational.c
@@ -111,15 +111,17 @@ rational_in_float(PG_FUNCTION_ARGS)
 {
 	float8		target = PG_GETARG_FLOAT8(0),
 				z,
-				prev_denom,
+				fnumer,
+				fdenom,
 				error;
 	int32		temp,
+				prev_denom,
 				sign;
 	Rational   *result = palloc(sizeof(Rational));
 
-	if (target == floor(target))
+	if (target == (int32)target)
 	{
-		result->numer = floor(target);
+		result->numer = (int32)target;
 		result->denom = 1;
 		PG_RETURN_POINTER(result);
 	}
@@ -127,16 +129,29 @@ rational_in_float(PG_FUNCTION_ARGS)
 	sign = target < 0.0 ? -1 : 1;
 	target = fabs(target);
 
+	if (target > INT32_MAX) {
+		ereport(ERROR,
+				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+				 errmsg("value too large for rational")));
+	}
 	z = target;
 	prev_denom = 0;
+	result->numer = (int32)round(target);
 	result->denom = 1;
 	do
 	{
 		z = 1.0 / (z - floor(z));
-		temp = result->denom;
-		result->denom = result->denom * floor(z) + prev_denom;
-		prev_denom = temp;
-		result->numer = round(target * result->denom);
+		fdenom = result->denom * floor(z) + prev_denom;
+		if (fdenom > INT32_MAX) {
+			break;
+		}
+		fnumer = round(target * fdenom);
+		if (fnumer > INT32_MAX) {
+			break;
+		}
+		prev_denom = result->denom;
+		result->numer = (int32)fnumer;
+		result->denom = (int32)fdenom;
 
 		error = fabs(target - ((float8) result->numer / (float8) result->denom));
 	} while (z != floor(z) && error >= 1e-12);

--- a/sql/pg_rational_test.sql
+++ b/sql/pg_rational_test.sql
@@ -23,6 +23,13 @@ select 0.263157894737::float::rational;
 select 3.141592625359::float::rational;
 select 0.606557377049::float::rational;
 select -0.5::float::rational;
+select 1.000001::float::rational;
+select 1.0000001::float::rational;
+select 1.00000001::float::rational;
+select 1.000000001::float::rational;
+select 1.0000000001::float::rational;
+select 2147483647::float::rational;
+select 2147483647.1::float::rational;
 
 -- to float
 select '1/2'::rational::float;

--- a/sql/pg_rational_test.sql
+++ b/sql/pg_rational_test.sql
@@ -30,6 +30,7 @@ select 1.000000001::float::rational;
 select 1.0000000001::float::rational;
 select 2147483647::float::rational;
 select 2147483647.1::float::rational;
+select 'NAN'::float::rational;
 
 -- to float
 select '1/2'::rational::float;


### PR DESCRIPTION
Overflow leads to wrong results and can create non-terminating loops
in the postgresql backend.

Changes:

 - return ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE when input is too large
   to be represented as rational

 - end refinement when the resulting numerator or denominator would
   not fit into an int32.

 - added some test cases