### PR TITLE
Document minimum required PostgreSQL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ precision in the denominator.
 * Implements Stern-Brocot trees for finding intermediate points
 * Coercion from integer/bigint/tuple
 * Custom aggregate
+* Supports PostgreSQL 11 and newer
 
 ### Motivation
 


### PR DESCRIPTION
We need at least PG11 where common/int.h was introduced.