### PR TITLE
Makefile: install 0.0.2 migration SQL script (fixes #16)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MODULES = pg_rational
 EXTENSION = pg_rational
-DATA = pg_rational--0.0.1.sql
+DATA = pg_rational--0.0.1.sql pg_rational--0.0.1--0.0.2.sql
 REGRESS = pg_rational_test
 PG_CPPFLAGS = -std=c99 -Wextra -Wpedantic
 


### PR DESCRIPTION
This causes the Makefile to correctly install and uninstall the 0.0.2 SQL file.