### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+# run the testsuite on travis-ci.com
+---
+# versions to run on
+env:
+  - PG_SUPPORTED_VERSIONS=9.4
+  - PG_SUPPORTED_VERSIONS=9.5
+  - PG_SUPPORTED_VERSIONS=9.6
+  - PG_SUPPORTED_VERSIONS=10
+  - PG_SUPPORTED_VERSIONS=11
+  - PG_SUPPORTED_VERSIONS=12
+  - PG_SUPPORTED_VERSIONS=13
+
+language: C
+dist: xenial
+
+before_install:
+  - sudo apt-get update -qq
+
+install:
+  # upgrade postgresql-common for new apt.postgresql.org.sh
+  - sudo apt-get install -y postgresql-common
+  - sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -p -v $PG_SUPPORTED_VERSIONS -i
+
+script:
+  - make
+  - sudo make install
+  - pg_virtualenv make installcheck
+  - if test -s regression.diffs; then cat regression.diffs; fi


### PR DESCRIPTION
Enable continuous integration tests on travis-ci.org.

To actually run the tests, you need to enable the repository on travis-ci.org first, and then push some change. (Enable first, then merge this.)