### PR TITLE
update example to match current Postgres behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ select '-1/2'::rational::float;
 Reorder items without renumbering surrounding items.
 
 ```sql
-create 
-todos_seq;
+create todos_seq;
 
 create table todos (
   prio rational unique

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ select '-1/2'::rational::float;
 Reorder items without renumbering surrounding items.
 
 ```sql
-create todos_seq;
+create sequence todos_seq;
 
 create table todos (
   prio rational unique

--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ select '-1/2'::rational::float;
 Reorder items without renumbering surrounding items.
 
 ```sql
-create sequence todos_seq;
+create 
+todos_seq;
 
 create table todos (
   prio rational unique
-    default nextval('todos_seq'),
+    default nextval('todos_seq')::float:rational,
   what text not null
 );
 


### PR DESCRIPTION
Fix example of using rational sequence. 
Not working without explicitly casting `bigint` to `rational`.